### PR TITLE
Add default variables.tf

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,3 @@
+variable "access_key" {}
+
+variable "secret_key" {}


### PR DESCRIPTION
This fixes the following error on running `terraform apply`:

```$ terraform apply

Error: provider config 'aws': unknown variable referenced: 'access_key'; define it with a 'variable' block



Error: provider config 'aws': unknown variable referenced: 'secret_key'; define it with a 'variable' block

```